### PR TITLE
Patch-Requirements.txt-pathlib2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ requests==2.22.0
 validators>=0.16
 geocoder>=1.38.1
 polyswarm-api>=2.1.2
-pathlib>=1.0.1
+pathlib>=2.0
 configparser>=5.0.0
 valhallaAPI>=0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ requests==2.22.0
 validators>=0.16
 geocoder>=1.38.1
 polyswarm-api>=2.1.2
-pathlib>=2.0
+pathlib2>=2.0
 configparser>=5.0.0
 valhallaAPI>=0.3.1


### PR DESCRIPTION
Update requirements.txt
pathlib is deprecated; pathlib2 looks like a viable alternative
**This patch only applies if pathlib2<=2.0 works for the app.**