### PR TITLE
Malwoverview 8.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Malwoverview
 
-[<img alt="GitHub release (latest by date)" src="https://img.shields.io/github/v/release/alexandreborges/malwoverview?color=red&style=for-the-badge">](https://github.com/alexandreborges/malwoverview/releases/tag/v8.0.4) [<img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/alexandreborges/malwoverview?color=Yellow&style=for-the-badge">](https://github.com/alexandreborges/malwoverview/releases) [<img alt="GitHub Release Date" src="https://img.shields.io/github/release-date/alexandreborges/malwoverview?label=Release%20Date&style=for-the-badge">](https://github.com/alexandreborges/malwoverview/releases) [<img alt="GitHub" src="https://img.shields.io/github/license/alexandreborges/malwoverview?style=for-the-badge">](https://github.com/alexandreborges/malwoverview/blob/master/LICENSE) 
+[<img alt="GitHub release (latest by date)" src="https://img.shields.io/github/v/release/alexandreborges/malwoverview?color=red&style=for-the-badge">](https://github.com/alexandreborges/malwoverview/releases/tag/v8.0.5) [<img alt="GitHub last commit" src="https://img.shields.io/github/last-commit/alexandreborges/malwoverview?color=Yellow&style=for-the-badge">](https://github.com/alexandreborges/malwoverview/releases) [<img alt="GitHub Release Date" src="https://img.shields.io/github/release-date/alexandreborges/malwoverview?label=Release%20Date&style=for-the-badge">](https://github.com/alexandreborges/malwoverview/releases) [<img alt="GitHub" src="https://img.shields.io/github/license/alexandreborges/malwoverview?style=for-the-badge">](https://github.com/alexandreborges/malwoverview/blob/master/LICENSE) 
 [<img alt="GitHub stars" src="https://img.shields.io/github/stars/alexandreborges/malwoverview?logoColor=Red&style=for-the-badge">](https://github.com/alexandreborges/malwoverview/stargazers)
 [<img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/ale_sp_brazil?style=for-the-badge&logo=X&color=blueviolet">](https://twitter.com/ale_sp_brazil)
 [![Downloads](https://static.pepy.tech/personalized-badge/malwoverview?period=month&units=international_system&left_color=grey&right_color=orange&left_text=Last%2030%20days)](https://pepy.tech/project/malwoverview)
@@ -46,7 +46,7 @@
       See GNU Public License on <http://www.gnu.org/licenses/>.
 
 
-## Current Version: 8.0.4 (Codename: Revolutions)
+## Current Version: 8.0.5 (Codename: Revolutions)
 
      Important note:  Malwoverview does NOT submit samples to any endpoint by default, 
      so it respects possible Non-Disclosure Agreements (NDAs). There're specific options
@@ -1421,6 +1421,36 @@ Use --help with any subcommand for details:
       malwoverview -vc 8 -VC CVE-2024-21412
 
 ## HISTORY
+
+Version 8.0.5:
+
+      This version:
+
+            * Improves the directory check against VirusTotal (-d option). The
+              "AV Detection" column is renamed to "AV", the Sample and other
+              columns are narrowed and realigned, and two new local-analysis
+              columns are added for each sample: "Overlay", indicating whether
+              the PE has an overlay (YES/NO, or N/A for non-PE files), and
+              "Ent", showing the file entropy as a value from 0.00 to 8.00. The
+              entropy is the highest per-section entropy of the PE (the best
+              signal for packed or encrypted sections), falling back to the
+              whole-file Shannon entropy for non-PE files.
+
+            * Shows the overlay size in the VirusTotal file report (-v 1/2/3).
+              When a PE has an overlay, an "Overlay Size" field is now printed
+              right below the "Overlay" field, formatted in KB/MB rather than
+              raw bytes.
+
+            * Shows overlay information in the VirusTotal hash report (-v 8).
+              The report by hash now reports whether the sample has an overlay
+              (and its size, in KB/MB) directly from VirusTotal's pe_info data,
+              without downloading the sample.
+
+            * Shows the file entropy in the VirusTotal file report (-v 1/2/3).
+              An "Entropy" field is now printed below the overlay information,
+              using the same value as the -d directory check: the highest
+              per-section entropy of the PE (0.00 to 8.00), falling back to the
+              whole-file Shannon entropy for non-PE files.
 
 Version 8.0.4:
 

--- a/malwoverview/malwoverview.py
+++ b/malwoverview/malwoverview.py
@@ -21,7 +21,7 @@
 # Corey Forman (https://github.com/digitalsleuth)
 # Christian Clauss (https://github.com/cclauss)
 
-# Malwoverview.py: version 8.0.4  (codename: Revolutions)
+# Malwoverview.py: version 8.0.5  (codename: Revolutions)
 
 import os
 import sys
@@ -68,7 +68,7 @@ import malwoverview.modules.configvars as cv
 __author__ = "Alexandre Borges"
 __copyright__ = "Copyright 2018-2026 Alexandre Borges"
 __license__ = "GNU General Public License v3.0"
-__version__ = "8.0.4"
+__version__ = "8.0.5"
 __email__ = "reverseexploit at proton.me"
 
 def finish_hook(signum, frame):

--- a/malwoverview/modules/virustotal.py
+++ b/malwoverview/modules/virustotal.py
@@ -2,7 +2,7 @@ import malwoverview.modules.configvars as cv
 from datetime import datetime
 from malwoverview.utils.colors import mycolors, printr
 from malwoverview.utils.hash import sha256hash
-from malwoverview.utils.peinfo import ftype, isoverlay, overextract, list_imports_exports
+from malwoverview.utils.peinfo import ftype, isoverlay, overlaysize, humansize, fileentropy, overextract, list_imports_exports
 import geocoder
 import validators
 import requests
@@ -52,8 +52,12 @@ class VirusTotalExtractor():
             mysha256hash = sha256hash(targetfile)
 
             magictype = ftype(targetfile)
+            ovrlsize = ''
             if re.match(r'^PE[0-9]{2}|^MS-DOS', magictype):
                 ret_overlay = isoverlay(targetfile)
+                if (ret_overlay == "YES"):
+                    ovrlsize = humansize(overlaysize(targetfile))
+            fent = "%.2f" % fileentropy(targetfile)
 
             if (showreport == 0):
                 self.vthashwork(mysha256hash, showreport)
@@ -61,18 +65,34 @@ class VirusTotalExtractor():
                 if re.match(r'^PE[0-9]{2}|^MS-DOS', magictype):
                     if (cv.bkg == 1):
                         print(mycolors.foreground.lightred + "Overlay: ".ljust(21) + mycolors.reset + ret_overlay, end='\n')
+                        if (ret_overlay == "YES"):
+                            print(mycolors.foreground.lightred + "Overlay Size: ".ljust(21) + mycolors.reset + ovrlsize, end='\n')
                 if re.match(r'^PE[0-9]{2}|^MS-DOS', magictype):
                     if (cv.bkg == 0):
                         print(mycolors.foreground.red + "Overlay: ".ljust(21) + mycolors.reset + ret_overlay, end='\n')
+                        if (ret_overlay == "YES"):
+                            print(mycolors.foreground.red + "Overlay Size: ".ljust(21) + mycolors.reset + ovrlsize, end='\n')
+                if (cv.bkg == 1):
+                    print(mycolors.foreground.lightred + "Entropy: ".ljust(21) + mycolors.reset + fent, end='\n')
+                if (cv.bkg == 0):
+                    print(mycolors.foreground.red + "Entropy: ".ljust(21) + mycolors.reset + fent, end='\n')
             else:
                 self.vtreportwork(mysha256hash, 1)
 
                 if re.match(r'^PE[0-9]{2}|^MS-DOS', magictype):
                     if (cv.bkg == 1):
                         print(mycolors.foreground.lightred + "Overlay: ".ljust(21) + mycolors.reset + ret_overlay, end='\n')
+                        if (ret_overlay == "YES"):
+                            print(mycolors.foreground.lightred + "Overlay Size: ".ljust(21) + mycolors.reset + ovrlsize, end='\n')
                 if re.match(r'^PE[0-9]{2}|^MS-DOS', magictype):
                     if (cv.bkg == 0):
                         print(mycolors.foreground.red + "Overlay: ".ljust(21) + mycolors.reset + ret_overlay, end='\n')
+                        if (ret_overlay == "YES"):
+                            print(mycolors.foreground.red + "Overlay Size: ".ljust(21) + mycolors.reset + ovrlsize, end='\n')
+                if (cv.bkg == 1):
+                    print(mycolors.foreground.lightred + "Entropy: ".ljust(21) + mycolors.reset + fent, end='\n')
+                if (cv.bkg == 0):
+                    print(mycolors.foreground.red + "Entropy: ".ljust(21) + mycolors.reset + fent, end='\n')
             if (impexp == 1):
                 list_imports_exports(targetfile)
             if (ovrly == 1):
@@ -1284,6 +1304,12 @@ class VirusTotalExtractor():
                         if ('imphash' in attrs['pe_info']):
                             imphash = attrs['pe_info']['imphash']
                             print(mycolors.foreground.yellow + "\n".ljust(22) + "Imphash: ".ljust(15) + mycolors.reset + str(imphash), end='')
+                        if ('overlay' in attrs['pe_info']):
+                            print(mycolors.foreground.yellow + "\n".ljust(22) + "Overlay: ".ljust(15) + mycolors.reset + "YES", end='')
+                            if ('size' in attrs['pe_info']['overlay']):
+                                print(mycolors.foreground.yellow + "\n".ljust(22) + "Overlay Size: ".ljust(15) + mycolors.reset + humansize(attrs['pe_info']['overlay']['size']), end='')
+                        else:
+                            print(mycolors.foreground.yellow + "\n".ljust(22) + "Overlay: ".ljust(15) + mycolors.reset + "NO", end='')
                         if ('import_list' in attrs['pe_info']):
                             print(mycolors.foreground.yellow + "\n".ljust(22) + "Libraries: ".ljust(15), end='')
                             for lib in attrs['pe_info']['import_list']:
@@ -1473,6 +1499,12 @@ class VirusTotalExtractor():
                         if ('imphash' in attrs['pe_info']):
                             imphash = attrs['pe_info']['imphash']
                             print(mycolors.foreground.blue + "\n".ljust(22) + "Imphash: ".ljust(15) + mycolors.reset + str(imphash), end='')
+                        if ('overlay' in attrs['pe_info']):
+                            print(mycolors.foreground.blue + "\n".ljust(22) + "Overlay: ".ljust(15) + mycolors.reset + "YES", end='')
+                            if ('size' in attrs['pe_info']['overlay']):
+                                print(mycolors.foreground.blue + "\n".ljust(22) + "Overlay Size: ".ljust(15) + mycolors.reset + humansize(attrs['pe_info']['overlay']['size']), end='')
+                        else:
+                            print(mycolors.foreground.blue + "\n".ljust(22) + "Overlay: ".ljust(15) + mycolors.reset + "NO", end='')
                         if ('import_list' in attrs['pe_info']):
                             print(mycolors.foreground.blue + "\n".ljust(22) + "Libraries: ".ljust(15), end='')
                             for lib in attrs['pe_info']['import_list']:
@@ -2005,18 +2037,30 @@ class VirusTotalExtractor():
 
             file_hash_dict = dict(list(zip(F, H)))
 
-            print("\nSample".center(10) + "Filename".center(72) + "Description".center(26) + "Threat Label".center(28) + "AV Detection".center(26))
-            print('-' * 154, end="\n\n")
+            print("\n" + "Sample".ljust(9) + "Filename".ljust(72) + "Description".ljust(30) + "Threat Label".ljust(34) + "AV".ljust(4) + "Overlay".center(9) + "Ent")
+            print('-' * 162, end="\n\n")
 
             hashnumber = 0
 
             for key, value in file_hash_dict.items():
                 hashnumber = hashnumber + 1
                 (type_description, threat_label, malicious) = self.vtbatchwork(value)
+                try:
+                    magictype = ftype(key)
+                except Exception:
+                    magictype = ''
+                if re.match(r'^PE[0-9]{2}|^MS-DOS', magictype):
+                    try:
+                        overlay = isoverlay(key)
+                    except Exception:
+                        overlay = "N/A"
+                else:
+                    overlay = "N/A"
+                entropy = "%.2f" % fileentropy(key)
                 if (cv.bkg == 1):
-                    print(mycolors.foreground.lightcyan + "file_" + str(hashnumber) + "\t   " + mycolors.reset + (key.strip()).ljust(71) + mycolors.foreground.yellow + (type_description).ljust(30) + mycolors.foreground.lightcyan + (threat_label).ljust(34) + mycolors.foreground.lightred + str(malicious))
+                    print(mycolors.foreground.lightcyan + ("file_" + str(hashnumber)).ljust(9) + mycolors.reset + (key.strip()).ljust(72) + mycolors.foreground.yellow + (type_description).ljust(30) + mycolors.foreground.lightcyan + (threat_label).ljust(34) + mycolors.foreground.lightred + str(malicious).ljust(4) + mycolors.foreground.yellow + overlay.center(9) + mycolors.foreground.lightcyan + entropy)
                 if (cv.bkg == 0):
-                    print(mycolors.foreground.blue + "file_" + str(hashnumber) + "\t   " + mycolors.reset + (key.strip()).ljust(71) + mycolors.foreground.cyan + (type_description).ljust(30) + mycolors.foreground.blue + (threat_label).ljust(34) + mycolors.foreground.red + str(malicious))
+                    print(mycolors.foreground.blue + ("file_" + str(hashnumber)).ljust(9) + mycolors.reset + (key.strip()).ljust(72) + mycolors.foreground.cyan + (type_description).ljust(30) + mycolors.foreground.blue + (threat_label).ljust(34) + mycolors.foreground.red + str(malicious).ljust(4) + mycolors.foreground.cyan + overlay.center(9) + mycolors.foreground.blue + entropy)
                 if (apitype_var == 1):
                     if ((hashnumber % 4) == 0):
                         time.sleep(61)

--- a/malwoverview/utils/peinfo.py
+++ b/malwoverview/utils/peinfo.py
@@ -2,6 +2,7 @@ import pefile
 from malwoverview.utils.colors import mycolors, printr
 import malwoverview.modules.configvars as cv
 import magic
+import math
 import os
 
 
@@ -18,6 +19,61 @@ def isoverlay(file_item):
     else:
         ovr = "YES"
     return ovr
+
+
+def rawentropy(file_item):
+    try:
+        with open(file_item, "rb") as f:
+            data = f.read()
+    except Exception:
+        return 0.0
+    if not data:
+        return 0.0
+    occurences = [0] * 256
+    for byte in data:
+        occurences[byte] += 1
+    entropy = 0.0
+    length = len(data)
+    for count in occurences:
+        if count:
+            p = float(count) / length
+            entropy -= p * math.log(p, 2)
+    return entropy
+
+
+def fileentropy(file_item):
+    try:
+        pe = pefile.PE(file_item)
+        sect_entropies = [section.get_entropy() for section in pe.sections]
+        if sect_entropies:
+            return max(sect_entropies)
+    except Exception:
+        pass
+    return rawentropy(file_item)
+
+
+def overlaysize(file_item):
+    try:
+        pe = pefile.PE(file_item)
+        offset = pe.get_overlay_data_start_offset()
+        if offset is None:
+            return 0
+        return os.path.getsize(file_item) - offset
+    except Exception:
+        return 0
+
+
+def humansize(num_bytes):
+    try:
+        num_bytes = float(num_bytes)
+    except (TypeError, ValueError):
+        return str(num_bytes)
+    for unit in ('bytes', 'KB', 'MB', 'GB', 'TB'):
+        if num_bytes < 1024.0 or unit == 'TB':
+            if unit == 'bytes':
+                return "%d bytes" % int(num_bytes)
+            return "%.2f %s" % (num_bytes, unit)
+        num_bytes /= 1024.0
 
 
 def overextract(fname):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "malwoverview"
-version = "8.0.4"
+version = "8.0.5"
 description = "Malwoverview is a first response tool for threat hunting."
 readme = "README.md"
 authors = [{name = "Alexandre Borges", email = "reverseexploit@proton.me"}]


### PR DESCRIPTION
      This version:

            * Improves the directory check against VirusTotal (-d option). The
              "AV Detection" column is renamed to "AV", the Sample and other
              columns are narrowed and realigned, and two new local-analysis
              columns are added for each sample: "Overlay", indicating whether
              the PE has an overlay (YES/NO, or N/A for non-PE files), and
              "Ent", showing the file entropy as a value from 0.00 to 8.00. The
              entropy is the highest per-section entropy of the PE (the best
              signal for packed or encrypted sections), falling back to the
              whole-file Shannon entropy for non-PE files.

            * Shows the overlay size in the VirusTotal file report (-v 1/2/3).
              When a PE has an overlay, an "Overlay Size" field is now printed
              right below the "Overlay" field, formatted in KB/MB rather than
              raw bytes.

            * Shows overlay information in the VirusTotal hash report (-v 8).
              The report by hash now reports whether the sample has an overlay
              (and its size, in KB/MB) directly from VirusTotal's pe_info data,
              without downloading the sample.

            * Shows the file entropy in the VirusTotal file report (-v 1/2/3).
              An "Entropy" field is now printed below the overlay information,
              using the same value as the -d directory check: the highest
              per-section entropy of the PE (0.00 to 8.00), falling back to the
              whole-file Shannon entropy for non-PE files.